### PR TITLE
Add visualization of goal points and tool path in rviz

### DIFF
--- a/kuka_kr10_gazebo/config/kuka_kr10_gazebo.rviz
+++ b/kuka_kr10_gazebo/config/kuka_kr10_gazebo.rviz
@@ -1,0 +1,185 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Path1
+        - /RobotModel1
+        - /Path2
+      Splitter Ratio: 0.5
+    Tree Height: 728
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /end_effector_path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 164; 0; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Billboards
+      Line Width: 0.004999999888241291
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /goal_path
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 1.9891927242279053
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.4792528450489044
+        Y: 0.042127449065446854
+        Z: 0.45277851819992065
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4447973966598511
+      Target Frame: camera_color_frame
+      Value: Orbit (rviz)
+      Yaw: 4.756089687347412
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1025
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001a400000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000003efc0100000002fb0000000800540069006d006501000000000000073d000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000047e0000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1853
+  X: 67
+  Y: 27

--- a/kuka_kr10_gazebo/launch/kr10_gazebo.launch
+++ b/kuka_kr10_gazebo/launch/kr10_gazebo.launch
@@ -1,15 +1,18 @@
 <?xml version="1.0"?>
 <launch>
   <!-- startup simulated world -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="worlds/empty.world"/>
   </include> 
-
   <!-- send robot URDF to ROS param server,
        and spawn robot in Gazebo, along with necessary ROS nodes -->
   <include file="$(find kuka_kr10_gazebo)/launch/spawn_kr10.launch"/>
 
   <!-- init and start Gazebo ros_control interface -->
   <include file="$(find kuka_kr10_gazebo)/launch/kr10_control.launch"/>
+
+  <!-- Visualize if you want -->
+  <node name="visualizer" pkg="kuka_kr10_gazebo" type="visualizer.py" output="screen"/>
+  <node type="rviz" name="rviz" pkg="rviz" args="-d $(find kuka_kr10_gazebo)/config/kuka_kr10_gazebo.rviz" />
 
 </launch>

--- a/kuka_kr10_gazebo/scripts/visualizer.py
+++ b/kuka_kr10_gazebo/scripts/visualizer.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import rospy
+
+from nav_msgs.msg import Path
+from geometry_msgs.msg import PoseStamped
+import numpy as np
+import tf 
+
+def check_motion(path, pose):
+	# return True
+	if len(path.poses) == 0:
+		return True
+	last_pose = path.poses[-1]
+	dx = pose.pose.position.x - last_pose.pose.position.x
+	dy = pose.pose.position.y - last_pose.pose.position.y
+	dz = pose.pose.position.z - last_pose.pose.position.z
+
+	dist = np.sqrt(dx*dx + dy*dy + dz*dz)
+
+	if dist > 0.0001:
+		return True
+	else:
+		return False
+
+def main():
+	rospy.init_node('tooltip_pose_publisher', anonymous=True)
+	rate = rospy.Rate(30.0)
+	path_pub = rospy.Publisher('/end_effector_path', Path, queue_size=1)
+	goal_path_pub = rospy.Publisher('/goal_path', Path, queue_size=1)
+	time_now = rospy.Time.now()
+	goal_path = Path()
+	goal_path.header.frame_id = 'base_link'
+	goal_points = [[0.6,0.,0.8], [0.6,-0.3,0.4], [0.6,0.,0.], [0.6,0.3,0.4], [0.6,0.,0.8]]
+	goal_path.header.stamp = time_now
+	for point in goal_points:
+		goal_pose = PoseStamped()
+		goal_pose.header.frame_id = 'base_link'
+		goal_pose.header.stamp = time_now
+		goal_pose.pose.position.x = point[0]
+		goal_pose.pose.position.y = point[1]
+		goal_pose.pose.position.z = point[2]
+		goal_pose.pose.orientation.x = 0
+		goal_pose.pose.orientation.y = 0
+		goal_pose.pose.orientation.z = 0
+		goal_pose.pose.orientation.w = 1
+		goal_path.poses.append(goal_pose)
+	
+	path = Path()
+	path.header.frame_id = 'base_link'
+	listener = tf.TransformListener()
+
+	while not rospy.is_shutdown():
+		try:
+			position, orientation = listener.lookupTransform('base_link', 'link_6', rospy.Time(0))
+		except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
+			continue
+
+		time_now = rospy.Time.now()
+		new_pose = PoseStamped()
+
+		new_pose.header.frame_id = 'base_link'
+		new_pose.header.stamp = time_now
+		new_pose.pose.position.x = position[0]
+		new_pose.pose.position.y = position[1]
+		new_pose.pose.position.z = position[2]
+		new_pose.pose.orientation.x = orientation[0]
+		new_pose.pose.orientation.y = orientation[1]
+		new_pose.pose.orientation.z = orientation[2]
+		new_pose.pose.orientation.w = orientation[3]
+		if check_motion(path, new_pose):
+			path.poses.append(new_pose)
+		path.header.stamp = time_now
+		# print(len(path.poses))
+
+		path_pub.publish(path)
+		goal_path_pub.publish(goal_path)
+		rate.sleep()
+
+
+if __name__ == '__main__':
+	try:
+		main()
+	except rospy.ROSInterruptException:
+		pass
+
+


### PR DESCRIPTION
Added following:

- visualizer.py: ros node that looks up tf of the end-effector link and stacks poses into a nav_msgs/path which is then published, along with a path through goal points (currently hard-coded)
- kuka_kr10_gazebo.rviz: rviz configuration that automatically displays the robot model and aforementioned paths

Changed:

- kr10_gazebo.launch: to enable automatic launch of the visualization node and rviz